### PR TITLE
Fix Edif::Runtime::WriteGlobal and Edif::Runtime::ReadGlobal

### DIFF
--- a/Lib/Edif.Runtime.cpp
+++ b/Lib/Edif.Runtime.cpp
@@ -1,4 +1,3 @@
-
 #include "Common.h"
 
 Edif::Runtime::Runtime(LPRDATA _rdPtr) : rdPtr(_rdPtr), ObjectSelection(_rdPtr->rHo.hoAdRunHeader)


### PR DESCRIPTION
Global Data was not working in EDIF because mvGetExtUserData and mvSetExtUserData want the hInstLib variable from General.cpp
