### PR TITLE
Add support for PARAM_CMPSTRING

### DIFF
--- a/Lib/Edif.cpp
+++ b/Lib/Edif.cpp
@@ -1,4 +1,3 @@
-
 #include "Common.h"
 
 Edif::SDK * SDK;
@@ -65,6 +64,9 @@ short ReadParameterType(const char * Text)
 
 	if(!_stricmp(Text, "Comparison"))
 		return PARAM_COMPARAISON;
+		
+	if(!_stricmp(Text, "StringComparison"))
+		return PARAM_CMPSTRING;
 
 	if(!_stricmp(Text, "Colour") || !_stricmp(Text, "Color"))
 		return PARAM_COLOUR;


### PR DESCRIPTION
There was support for PARAM_COMPARAISON, but not PARAM_CMPSTRING. 
