### PR TITLE
Add batch to auto copy built MFXs to MMF2

### DIFF
--- a/Extensions/AutoInstall.bat
+++ b/Extensions/AutoInstall.bat
@@ -1,0 +1,44 @@
+echo MFX File: %1
+echo MFX Destination: %2
+
+:mfd
+set status=ERROR
+for /F "tokens=*" %%A in ('REG QUERY "HKEY_LOCAL_MACHINE\SOFTWARE\Clickteam\Multimedia Fusion Developer 2\Settings" /v "ProPath"') do set status=%%A
+set status=%status:~0,5%
+if %status%==ERROR goto nmfd
+
+for /F "tokens=3* delims= " %%A in ('REG QUERY "HKEY_LOCAL_MACHINE\SOFTWARE\Clickteam\Multimedia Fusion Developer 2\Settings" /v "ProPath" ^| find "REG_SZ"') do set mmfpath=%%A %%B
+
+echo MMF2 Dev Path: %mmfpath%
+
+copy /y "%1" "%mmfpath%%2"
+
+set mmfpath=
+set status=
+
+goto mfs
+
+:nmfd
+echo You don't have MMF2 Developer :(
+
+:mfs
+set status=ERROR
+for /F "tokens=1 delims=:" %%A in ('REG QUERY "HKEY_LOCAL_MACHINE\SOFTWARE\Clickteam\Multimedia Fusion 2\Settings" /v "StdPath"') do set status=%%A
+set status=%status:~0,5%
+if %status%==ERROR goto nmfs
+
+for /F "tokens=3* delims= " %%A in ('REG QUERY "HKEY_LOCAL_MACHINE\SOFTWARE\Clickteam\Multimedia Fusion 2\Settings" /v "StdPath" ^| find "REG_SZ"') do set mmfpath=%%A %%B
+
+echo MMF2 Std Path: %mmfpath%
+
+copy /y "%1" "%mmfpath%%2"
+
+set mmfpath=
+set status=
+
+goto end
+
+:nmfs
+echo You don't have MMF2 Standard
+
+:end

--- a/Extensions/Template/Template.vcproj
+++ b/Extensions/Template/Template.vcproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="Windows-1252"?>
 <VisualStudioProject
 	ProjectType="Visual C++"
-	Version="9,00"
+	Version="9.00"
 	Name="Template"
 	ProjectGUID="{3BCB4C73-71F6-43B6-803D-41411F92652A}"
 	RootNamespace="Template"
@@ -115,7 +115,7 @@
 			/>
 			<Tool
 				Name="VCPostBuildEventTool"
-				CommandLine=""
+				CommandLine="..\AutoInstall.bat $(TargetPath) \Extensions"
 			/>
 		</Configuration>
 		<Configuration
@@ -216,6 +216,8 @@
 			/>
 			<Tool
 				Name="VCPostBuildEventTool"
+				Description=""
+				CommandLine="..\AutoInstall.bat $(TargetPath) \Extensions"
 			/>
 		</Configuration>
 		<Configuration
@@ -317,7 +319,7 @@
 			/>
 			<Tool
 				Name="VCPostBuildEventTool"
-				CommandLine=""
+				CommandLine="..\AutoInstall.bat $(TargetPath) \Data\Runtime"
 			/>
 		</Configuration>
 		<Configuration
@@ -418,6 +420,7 @@
 			/>
 			<Tool
 				Name="VCPostBuildEventTool"
+				CommandLine="..\AutoInstall.bat $(TargetPath) \Extensions\Unicode"
 			/>
 		</Configuration>
 		<Configuration
@@ -520,7 +523,7 @@
 			/>
 			<Tool
 				Name="VCPostBuildEventTool"
-				CommandLine=""
+				CommandLine="..\AutoInstall.bat $(TargetPath) \Extensions\Unicode"
 			/>
 		</Configuration>
 		<Configuration
@@ -623,7 +626,7 @@
 			/>
 			<Tool
 				Name="VCPostBuildEventTool"
-				CommandLine=""
+				CommandLine="..\AutoInstall.bat $(TargetPath) \Data\Runtime\Unicode"
 			/>
 		</Configuration>
 		<Configuration
@@ -724,6 +727,7 @@
 			/>
 			<Tool
 				Name="VCPostBuildEventTool"
+				CommandLine="..\AutoInstall.bat $(TargetPath) \Extensions\HWA"
 			/>
 		</Configuration>
 		<Configuration
@@ -826,7 +830,7 @@
 			/>
 			<Tool
 				Name="VCPostBuildEventTool"
-				CommandLine=""
+				CommandLine="..\AutoInstall.bat $(TargetPath) \Extensions\HWA"
 			/>
 		</Configuration>
 		<Configuration
@@ -928,7 +932,7 @@
 			/>
 			<Tool
 				Name="VCPostBuildEventTool"
-				CommandLine=""
+				CommandLine="..\AutoInstall.bat $(TargetPath) \Data\Runtime\HWA"
 			/>
 		</Configuration>
 	</Configurations>


### PR DESCRIPTION
I wrote a batch file to copy built MFXs to MMF2 Standard and Dev automatically and added it as a post-build event. It uses the registry to detect the installation paths for standard and developer.
