### PR TITLE
Fix garbage value being returned with optimizations enabled

### DIFF
--- a/Lib/Edif.cpp
+++ b/Lib/Edif.cpp
@@ -428,6 +428,7 @@ int ActionOrCondition(vector<short> &FloatFlags, LPEVENTINFOS2 Info, void * Func
 {
     int * Parameters;
     int ParameterCount;
+	bool Cast = true;
 
     {   Info = GetEventInformations(Info, ID);
 
@@ -454,6 +455,12 @@ int ActionOrCondition(vector<short> &FloatFlags, LPEVENTINFOS2 Info, void * Func
 
                 Parameters[i] = CNC_GetStringParameter(rdPtr);
                 break;
+
+			case PARAM_COMPARAISON: //int must be returned
+			case PARAM_CMPSTRING: //char * must be returned
+
+				Cast = false;
+				break;
 
             default:
 
@@ -504,7 +511,7 @@ int ActionOrCondition(vector<short> &FloatFlags, LPEVENTINFOS2 Info, void * Func
         popad
     }
 
-    return Result;
+    return Cast ? (char)Result : Result;
 }
 
 HMENU Edif::LoadMenuJSON(int BaseID, const json_value &Source, HMENU Parent)


### PR DESCRIPTION
This is related to https://github.com/ClickteamLLC/windows-edif/issues/3
See [this post](http://community.clickteam.com/threads/60946-Request-Beg-JSON-Object?p=599554&viewfull=1#post599554).
This affects conditions with optimizations enabled.
