### PR TITLE
Update AutoInstall.bat for Fusion 2.5

### DIFF
--- a/Extensions/AutoInstall.bat
+++ b/Extensions/AutoInstall.bat
@@ -36,9 +36,49 @@ copy /y "%1" "%mmfpath%%2"
 set mmfpath=
 set status=
 
-goto end
+goto cfd
 
 :nmfs
 echo You don't have MMF2 Standard
+
+:cfd
+set status=ERROR
+for /F "tokens=1 delims=:" %%A in ('REG QUERY "HKEY_LOCAL_MACHINE\SOFTWARE\Clickteam\Fusion Developer 2.5\Settings" /v "InstallPath"') do set status=%%A
+set status=%status:~0,5%
+if %status%==ERROR goto ncfd
+
+for /F "tokens=3* delims= " %%A in ('REG QUERY "HKEY_LOCAL_MACHINE\SOFTWARE\Clickteam\Fusion Developer 2.5\Settings" /v "InstallPath" ^| find "REG_SZ"') do set mmfpath=%%A %%B
+
+echo CTF2.5 Dev Path: %mmfpath%
+
+copy /y "%1" "%mmfpath%%2"
+
+set mmfpath=
+set status=
+
+goto cfs
+
+:ncfd
+echo You don't have CTF2.5 Developer :(
+
+:cfs
+set status=ERROR
+for /F "tokens=1 delims=:" %%A in ('REG QUERY "HKEY_LOCAL_MACHINE\SOFTWARE\Clickteam\Fusion 2.5\Settings" /v "InstallPath"') do set status=%%A
+set status=%status:~0,5%
+if %status%==ERROR goto ncfs
+
+for /F "tokens=3* delims= " %%A in ('REG QUERY "HKEY_LOCAL_MACHINE\SOFTWARE\Clickteam\Fusion 2.5\Settings" /v "InstallPath" ^| find "REG_SZ"') do set mmfpath=%%A %%B
+
+echo CTF2.5 Std Path: %mmfpath%
+
+copy /y "%1" "%mmfpath%%2"
+
+set mmfpath=
+set status=
+
+goto end
+
+:ncfs
+echo You don't have CTF2.5 Standard
 
 :end


### PR DESCRIPTION
The batch file now also detects Fusion 2.5 installations and copies built MFXs just like with Fusion 2.0
