### PR TITLE
Work around double call to init/free in F2.5

### DIFF
--- a/Lib/Edif.cpp
+++ b/Lib/Edif.cpp
@@ -1,6 +1,6 @@
 #include "Common.h"
 
-Edif::SDK * SDK;
+Edif::SDK * SDK = 0;
 
 TCHAR Edif::LanguageCode[3];
 
@@ -120,9 +120,7 @@ void Edif::Init(mv * _far mV, LPEDATA edPtr)
 }
 
 void Edif::Free(mv * _far mV)
-{   
-	delete ::SDK;
-	::SDK = NULL;
+{
 }
 
 void Edif::Free(LPEDATA edPtr)
@@ -206,7 +204,8 @@ int Edif::Init(mv _far * mV)
         return -1;
     }
 
-    ::SDK = new Edif::SDK(mV, *json);
+	static Edif::SDK gSDK (mV, *json);
+    ::SDK = &gSDK;
     return 0;	// no error
 }
 


### PR DESCRIPTION
This attempts to work around [CT#1650](http://bugbox.clickteam.com/issues/1650), which causes A/C/Es to be unlinked after creation of a sub-app and aso causes the global SDK object to be deleted upon destruction of any sub-app, which causes a crash the next time the global SDK pointer has to be dereferenced.

The workaround uses a static local variable to construct the global SDK object the first time and then assign its address to the global SDK pointer. It seems to work as expected, but might cause unexpected results if Fusion does not unload and reload the extension MFX after calling Free and before calling Initialize, though I have never been able to find a case where this happens (and I am very doubtful that this may happen in the future).