### PR TITLE
Fixed ObjectSelection to Filter Qualifiers, & Fix to CurrentParam. Example Scoping Condition.

### DIFF
--- a/Extensions/Template/Conditions.cpp
+++ b/Extensions/Template/Conditions.cpp
@@ -6,4 +6,23 @@ bool Extension::AreTwoNumbersEqual(int First, int Second)
     return First == Second;
 }
 
+bool ObjectXFilter(Extension* Ext, RunObject* Obj)
+{
+	return Obj->roHo.hoX == Ext->XPositionCompare;
+}
+
+bool Extension::ObjectsXEquals(RunObject* Object, int XPosition)
+{
+	LPEVP pParam = rdPtr->rHo.hoCurrentParam;
+	// pParam points to 1st parameter, which should be of type object
+	// Offset it if you have used second or other parameter for object selection using code below
+	// LPEVP pParam2nd = (LPEVP)((LPBYTE)pParam + pParam->evpSize);
+
+	short oil = (short)pParam->evp.evpW.evpW0;
+	bool negated = ((event*)((LPBYTE)rdPtr->rHo.hoCurrentParam - CND_SIZE))->evtFlags2 & EVFLAG2_NOT;
+	XPositionCompare = XPosition;
+
+	return Runtime.ObjectSelection.FilterObjects(this, oil, negated, ObjectXFilter);
+}
+
 

--- a/Extensions/Template/Ext.json
+++ b/Extensions/Template/Ext.json
@@ -26,6 +26,10 @@
         [
             0,
             "Are two numbers equal?"
+        ],  
+        [
+            1,
+            "Is an object's X Position equal to?"
         ]
     ],
     "ExpressionMenu": [
@@ -59,10 +63,24 @@
                 [
                     "Integer",
                     "First number"
-                ],
+                ],  
                 [
                     "Integer",
                     "Second number"
+                ]
+            ],
+            "Triggered": false
+        },
+        {
+            "Title": "%o : %0's X Position equals %1?",
+            "Parameters": [
+                [
+                    "Object",
+                    "The object to select"
+                ],  
+                [
+                    "Integer",
+                    "The X Position to compare to"
                 ]
             ],
             "Triggered": false

--- a/Extensions/Template/Extension.cpp
+++ b/Extensions/Template/Extension.cpp
@@ -18,6 +18,7 @@ Extension::Extension(LPRDATA _rdPtr, LPEDATA edPtr, fpcob cobPtr)
     LinkAction(1, SecondActionExample);
 
     LinkCondition(0, AreTwoNumbersEqual);
+    LinkCondition(1, ObjectsXEquals);
 
     LinkExpression(0, Add);
     LinkExpression(1, HelloWorld);

--- a/Extensions/Template/Extension.h
+++ b/Extensions/Template/Extension.h
@@ -29,7 +29,7 @@ public:
     */
 
     // int MyVariable;
-
+	int XPositionCompare = 0;
 
 
 
@@ -49,6 +49,7 @@ public:
     /// Conditions
 
         bool AreTwoNumbersEqual(int FirstNumber, int SecondNumber);
+		bool ObjectsXEquals(RunObject* Obj, int XPosition);
 
     /// Expressions
         

--- a/Lib/Edif.cpp
+++ b/Lib/Edif.cpp
@@ -479,6 +479,7 @@ Edif::SDK::~SDK()
 
 int ActionOrCondition(vector<short> &FloatFlags, LPEVENTINFOS2 Info, void * Function, int ID, LPRDATA rdPtr, long param1, long param2)
 {
+	LPEVP pParam = rdPtr->rHo.hoCurrentParam;
     int * Parameters;
     int ParameterCount;
 	bool Cast = true;
@@ -526,6 +527,8 @@ int ActionOrCondition(vector<short> &FloatFlags, LPEVENTINFOS2 Info, void * Func
     void * Extension = rdPtr->pExtension;
 
     int Result;
+
+	rdPtr->rHo.hoCurrentParam = pParam;
 
     __asm
     {

--- a/Lib/ObjectSelection.cpp
+++ b/Lib/ObjectSelection.cpp
@@ -178,21 +178,22 @@ bool Riggs::ObjectSelection::FilterQualifierObjects(Extension* extension, short 
 	LPOIL pObjectInfo = GetOIL(oiList);
 	if(pObjectInfo == NULL)
 		return false;
-	short Oi = pObjectInfo->oilOi;
 
-    LPQOI CurrentQualToOiStart = (LPQOI)((char*)QualToOiList + Oi);
-    LPQOI CurrentQualToOi = CurrentQualToOiStart;
+	bool hasSelected = false;
+	this->QualToOiList = rhPtr->rhQualToOiList;
+	LPQOI CurrentQualToOiStart = (LPQOI)((char*)QualToOiList + oiList);
+	LPQOI CurrentQualToOi = CurrentQualToOiStart;
 
-    bool hasSelected = false;
-	int i=0;
+	if (CurrentQualToOi == NULL)
+		return false;
 
-	LPSHORT ptr=&CurrentQualToOi->qoiOi;
-	/*while( ptr != -1 )
-    {
-        short CurrentOi = GetOIL(CurrentQualToOi->qoiOiList);
-        hasSelected |= FilterNonQualifierObjects(extension, CurrentOi->oilOi, negate, filterFunction);
-        CurrentQualToOi = (LPQOI)((char*)CurrentQualToOi + 4);
-    }*/
+	while (CurrentQualToOi->qoiOiList >= 0)
+	{
+		hasSelected |= FilterNonQualifierObjects(extension, CurrentQualToOi->qoiOiList, negate, filterFunction);
+		CurrentQualToOi = (LPQOI)((char*)CurrentQualToOi + 4);
+		if (CurrentQualToOi == NULL)
+			break;
+	}
     return hasSelected;
 }
 
@@ -220,10 +221,7 @@ bool Riggs::ObjectSelection::FilterNonQualifierObjects(Extension* extension, sho
     while(current >= 0)
     {
         LPHO pObject = ObjectList[current].oblOffset;
-        bool useObject = filterFunction(extension, (LPRO)pObject);
-
-        if(negate)
-            useObject = !useObject;
+        bool useObject = filterFunction(extension, (LPRO)pObject) ^ negate;
 
         hasSelected |= useObject;
 


### PR DESCRIPTION
ObjectSelection had FilterQualifierObjects mostly commented out, so I have written working code for it.

This request also includes fix proposed by Yves for CurrentParam so that it points to the first parameter in a condition or action, inside Edif.cpp lines 482 & 531.

I've included an example condition that filters object of a chosen type, hoping that will be useful for anyone who would like to delve into object selection.